### PR TITLE
Remove path from param keys flag

### DIFF
--- a/checkenv.go
+++ b/checkenv.go
@@ -65,7 +65,7 @@ func AddValueQuotes(val string, showQuotes bool) string {
 	return val
 }
 
-// Cut off the path and return only the value after the '/'.
+// Cut off the path and return only the key after the '/'.
 func RemoveKeyPath(key string, removePath bool) string {
 	if removePath {
 		valSlice := strings.Split(key, "/")
@@ -87,7 +87,7 @@ func main() {
 	showFlags.BoolVar(showHelp, "help", false, "Use this flag if you want help with this command")
 	showExport := showFlags.Bool("export", false, "Use this flag to prepend and \"export \" before every environment variable definition")
 	showQuotes := showFlags.Bool("quotes", false, "Use this flag to put value in quotes")
-	showRemovePath := showFlags.Bool("remove-path", false, "Use this flag to cut off the path and return only the value after the '/'")
+	showRemovePath := showFlags.Bool("remove-path", false, "Use this flag to cut off the path and return only the key after the '/'")
 	showRaw := showFlags.Bool("raw", false, "Use this flag to prevent comments output")
 	showValue := showFlags.Bool("value", false, "Print value only")
 	showName := showFlags.Bool("name", false, "Print name only")

--- a/checkenv.go
+++ b/checkenv.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const CHECKENV_VERSION = "v0.0.5"
+const CHECKENV_VERSION = "v0.0.6"
 
 type showSpec struct {
 	loadFrom      map[string]interface{}
@@ -65,6 +65,16 @@ func AddValueQuotes(val string, showQuotes bool) string {
 	return val
 }
 
+// Cut off the path and return only the value after the '/'.
+func RemoveKeyPath(key string, removePath bool) string {
+	if removePath {
+		valSlice := strings.Split(key, "/")
+		return valSlice[len(valSlice)-1]
+	}
+
+	return key
+}
+
 func main() {
 	pluginsCommand := "plugins"
 	pluginsFlags := flag.NewFlagSet("plugins", flag.ExitOnError)
@@ -77,6 +87,7 @@ func main() {
 	showFlags.BoolVar(showHelp, "help", false, "Use this flag if you want help with this command")
 	showExport := showFlags.Bool("export", false, "Use this flag to prepend and \"export \" before every environment variable definition")
 	showQuotes := showFlags.Bool("quotes", false, "Use this flag to put value in quotes")
+	showRemovePath := showFlags.Bool("remove-path", false, "Use this flag to cut off the path and return only the value after the '/'")
 	showRaw := showFlags.Bool("raw", false, "Use this flag to prevent comments output")
 	showValue := showFlags.Bool("value", false, "Print value only")
 	showName := showFlags.Bool("name", false, "Print name only")
@@ -136,11 +147,11 @@ func main() {
 			}
 			for k, v := range providedVars[providerSpec] {
 				if !*showValue && !*showName {
-					fmt.Printf("%s%s=%s\n", exportPrefix, k, AddValueQuotes(v, *showQuotes))
+					fmt.Printf("%s%s=%s\n", exportPrefix, RemoveKeyPath(k, *showRemovePath), AddValueQuotes(v, *showQuotes))
 				} else if *showValue {
 					fmt.Printf("%s\n", AddValueQuotes(v, *showQuotes))
 				} else if *showName {
-					fmt.Printf("%s\n", k)
+					fmt.Printf("%s\n", RemoveKeyPath(k, *showRemovePath))
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

If used flag `--remove-path` it cut off the path and return only the key after the '/'.

## How to test these changes?

Tested locally.

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
